### PR TITLE
[PL-61] GitHub Actions Node 20 런타임 지원 종료 대응

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout Project Package
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout Project Package
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
 
     - name: Install Dependencies
       run: uv sync --group dev
@@ -39,7 +39,7 @@ jobs:
       run: uv run pytest tests/ --cov=src/ --cov-report xml:coverage.xml
 
     - name: Report Coverage
-      uses: orgoro/coverage@v3.1
+      uses: orgoro/coverage@v3.3.1
       with:
         coverageFile: coverage.xml
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,10 +49,10 @@ jobs:
 
     steps:
     - name: Checkout Project Package
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
 
     - name: Install Dependencies
       run: uv sync --group dev

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## 배경

GitHub Actions 러너의 **Node 20 런타임 지원이 종료**됩니다(2026-06-16 Node 24 기본 전환 / 2026-09-16 Node 20 제거). JavaScript 액션은 러너 Node 런타임으로 실행되므로, Node 20(및 더 오래된 node16/12)으로 동작하던 액션을 Node 24 지원 버전으로 상향합니다.

- 공지: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- 조직 전체 전수조사(PL-61)의 일환.

## 변경 사항 (Node 24 지원 최소 메이저)

| 액션 | 변경 | 검증 |
|------|------|------|
| `actions/checkout` | @v4 → @v5 | ✅ 기검증 |
| `astral-sh/setup-uv` | @v5 → @v7 | ✅ 기검증 |
| `orgoro/coverage` | @v3.1 → @v3.3.1 | ✅ 기검증 |
| `release-drafter/release-drafter` | @v5 → @v7 | ✅ 기검증 |


## 검증

- **✅ 기검증**: 앞선 PL-61 PR들(eight #23625, fep·rwa 계열 등 머지 완료)의 CI/CD 실행에서 Node 24 정상 동작이 확인된 버전입니다.

## 참고
- Jira: [PL-61](https://8percent.atlassian.net/browse/PL-61)


[PL-61]: https://8percent.atlassian.net/browse/PL-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ